### PR TITLE
Change ShippingType from enum to string list

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,10 +57,7 @@ interface Buyer {
     billingAddress?: BillingAddress;
 }
 
-enum ShippingType {
-    ST = 'ST',
-    SD = 'SD',
-}
+type ShippingType = "ST" | "SD";
 
 interface ShippingAddress extends BillingAddress {
     firstName: string;


### PR DESCRIPTION
This makes `ShippingType` still non-exportable (if intended) while only allowing enumerated values on string list.