### PR TITLE
Export definition for enum ShippingType (#12)

### DIFF
--- a/dist/interfaces.d.ts
+++ b/dist/interfaces.d.ts
@@ -50,7 +50,7 @@ interface Buyer {
     shippingAddress?: ShippingAddress;
     billingAddress?: BillingAddress;
 }
-declare enum ShippingType {
+export declare enum ShippingType {
     ST = "ST",
     SD = "SD"
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,7 +57,7 @@ interface Buyer {
     billingAddress?: BillingAddress;
 }
 
-enum ShippingType {
+export enum ShippingType {
     ST = 'ST',
     SD = 'SD',
 }


### PR DESCRIPTION
This change exports the enum `ShippingType`.

As reported in #12... Because `ShippingType` is not exported in the type definition of the package, users cannot properly use the SDK in a type strict environment (i.e., TypeScript). Using string values is not an option since that is still flagged by type checkers (string is a different type from ShippingType).